### PR TITLE
Must be all in lower-case and without any spaces.

### DIFF
--- a/custom-post-type-maker.php
+++ b/custom-post-type-maker.php
@@ -785,7 +785,7 @@ class Cptm {
 			<tr>
 				<td class="label">
 					<label for="cptm_tax_name"><span class="required">*</span> <?php _e( 'Custom Taxonomy Name', 'custom-post-type-maker' ); ?></label>
-					<p><?php _e( 'The taxonomy name. Used to retrieve custom taxonomy content.', 'custom-post-type-maker' ); ?></p>
+					<p><?php _e( 'The taxonomy name. Used to retrieve custom taxonomy content. Must be all in lower-case and without any spaces.', 'custom-post-type-maker' ); ?></p>
 					<p><?php _e( 'e.g. movies', 'custom-post-type-maker' ); ?></p>
 				</td>
 				<td>


### PR DESCRIPTION
add descriptive text similar to creating new CTP. to help less experienced users avoid creating invalid name. invalid name seems to cause strange display in the taxonomy cloud to display "0" instead of "no items found" or list of the most used items.
